### PR TITLE
Wrap logos in links

### DIFF
--- a/profile/README.md
+++ b/profile/README.md
@@ -9,27 +9,27 @@ Our beloved mascot is the [Numbat](https://en.wikipedia.org/wiki/Numbat).
 There are 5 key projects in our Numerical Elixir effort. We will briefly summarize them below and draw comparisons
 to other ecosystems to help developers familiarize with our work.
 
-<h3><img src="https://github.com/elixir-nx/nx/raw/main/nx/nx.png" alt="Nx" width="120" style="margin-top: 10px"></h3>
+<h3><a href="https://github.com/elixir-nx/nx"><img src="https://github.com/elixir-nx/nx/raw/main/nx/nx.png" alt="Nx" width="120" style="margin-top: 10px"></a></h3>
 
 <a href="https://github.com/elixir-nx/nx">Nx</a> stands for Numerical Elixir and it is the project that started it all.
 Nx is a multi-dimensional tensors library with multi-staged compilation to the CPU/GPU. It plays a similar role to Numpy
 in the Elixir community. It is inspired by Google's [`JAX`](https://github.com/google/jax) and ships with its own Tensor
 Serving implementation that can run concurrently, distributed over multiple nodes, as well as partitioned across several GPUs.
 
-<h3><img src="https://github.com/livebook-dev/livebook/raw/main/static/images/logo-with-text.png" alt="Livebook" width="250" style="margin: 10px 0 -15px -15px"></h3>
+<h3><a href="https://livebook.dev/"><img src="https://github.com/livebook-dev/livebook/raw/main/static/images/logo-with-text.png" alt="Livebook" width="250" style="margin: 10px 0 -15px -15px"></a></h3>
 
 <a href="https://livebook.dev/">Livebook</a> brings the next generation of open-source local-first notebooks to Elixir.
 With Livebook you can write interactive and collaborative notebooks, which are truly reproducible, all the way to package
 management. If you are not yet familiar with Elixir, Livebook and its smart cells are one of the best ways to get started,
 and it features [a growing ecosystem of integrations](https://livebook.dev/integrations).
 
-<h3><img src="https://github.com/elixir-nx/explorer/raw/main/explorer.png" alt="Explorer" width="200" style="margin: 10px 0 -15px -15px"></h3>
+<h3><a href="https://github.com/elixir-nx/explorer"><img src="https://github.com/elixir-nx/explorer/raw/main/explorer.png" alt="Explorer" width="200" style="margin: 10px 0 -15px -15px"></a></h3>
 
 <a href="https://github.com/elixir-nx/explorer">Explorer</a> brings series (one-dimensional) and dataframes (two-dimensional)
 for fast data exploration to Elixir. It brings the power of Rust [via the Polars library](https://github.com/pola-rs/polars)
 and it is inspired by [dplyr (from the R community)](https://dplyr.tidyverse.org/).
 
-<h3><img src="https://github.com/elixir-nx/axon/raw/main/axon.png" alt="Axon" width="200" style="margin: 10px 0 -15px -15px"></h3>
+<h3><a href="https://github.com/elixir-nx/axon"><img src="https://github.com/elixir-nx/axon/raw/main/axon.png" alt="Axon" width="200" style="margin: 10px 0 -15px -15px"></a></h3>
 
 <a href="https://github.com/elixir-nx/axon">Axon</a> is a Nx-powered Neural Network library. It splits out into four components:
 a Functional API of numerical functions, a high-level Model Creation API, an Optimization API based on [Optax](https://github.com/deepmind/optax),
@@ -41,7 +41,7 @@ Neural Networks with [Hugging Face Models integration](https://huggingface.co/mo
 
 For integration with other platforms, check out [AxonONNX](https://github.com/elixir-nx/axon_onnx).
 
-<h3><img src="https://github.com/elixir-nx/scholar/raw/main/images/scholar.png" alt="Scholar" width="220" style="margin: 5px 0 -25px -15px"></h3>
+<h3><a href="https://github.com/elixir-nx/scholar"><img src="https://github.com/elixir-nx/scholar/raw/main/images/scholar.png" alt="Scholar" width="220" style="margin: 5px 0 -25px -15px"></a></h3>
 
 <a href="https://github.com/elixir-nx/scholar">Scholar</a> is the most recent addition to the Nx ecosystem and it focus on
 traditional machine learning techniques, such as classification, regression, clustering, dimensionality reduction, metrics,


### PR DESCRIPTION
When first visiting the profile it is natural to want to click on the logos to access the projects. However currently clicking the logos merely brings you to a full-size version of the logo which is probably not what most people want.

The resulting readme can be previewed at https://github.com/axelson/.github/tree/link-logos/profile